### PR TITLE
chore(l10n_do_accounting): uninstall l10n_do_credit_note on upgrade

### DIFF
--- a/src/l10n_do_accounting/19.0.2.0.0/post-uninstall-l10n_do_credit_note.py
+++ b/src/l10n_do_accounting/19.0.2.0.0/post-uninstall-l10n_do_credit_note.py
@@ -1,0 +1,22 @@
+import logging
+
+from odoo.addons.base.maintenance.migrations import util
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Uninstall l10n_do_credit_note, merged into l10n_do_accounting.
+
+    Runs as a post-script: by then l10n_do_accounting 19.0.2.0.0 already owns
+    the company fields absorbed from the module (l10n_do_fiscal_position_id,
+    l10n_do_day_months, credit_note_company_currency), so the uninstall keeps
+    their columns and values.
+    """
+    module_name = "l10n_do_credit_note"
+    if util.module_installed(cr, module_name):
+        _logger.info("Uninstalling module: %s", module_name)
+        util.uninstall_module(cr, module_name)
+        _logger.info("Successfully uninstalled module: %s", module_name)
+    else:
+        _logger.info("Module %s is not installed, skipping.", module_name)


### PR DESCRIPTION
## Summary

Uninstalls `l10n_do_credit_note` from upgraded databases. The module was merged into `l10n_do_accounting` 19.0.2.0.0 (indexa-git/odoo-pro#970 / #971): credit notes now inherit `invoice_currency_rate` from the reversed invoice and the >30-days ITBIS rule lives in the localization core.

## Why a post-script under `l10n_do_accounting/19.0.2.0.0`

The script is anchored on the same module and version that absorbs the logic (odoo-pro#971), so ordering is guaranteed by the upgrade phases themselves: by post time, `l10n_do_accounting` already owns the three company fields that survive the merge (`l10n_do_fiscal_position_id`, `l10n_do_day_months`, `credit_note_company_currency`), and `util.uninstall_module` only removes records solely owned by the uninstalled module — the columns and their values are preserved with no extra handling.

Idempotent: no-op when the module is not installed (fresh databases, or already cleaned up by `l10n_do_accounting`'s own `upgrades/19.0.2.0.0` migration in odoo-pro#971).

## Related

- indexa-git/odoo-pro#970 (module removal)
- indexa-git/odoo-pro#971 (logic absorbed into l10n_do_accounting + rate fix)
- indexa-git/odoo-pro#972 (e-CF TipoCambio from document rate)