### PR TITLE
fix(l10n_do_banks): retire OCA hr_employee_relative in the end stage

### DIFF
--- a/src/l10n_do_banks/19.0.1.0.0/end-10-retire-hr-employee-relative.py
+++ b/src/l10n_do_banks/19.0.1.0.0/end-10-retire-hr-employee-relative.py
@@ -1,0 +1,35 @@
+import logging
+
+from odoo.upgrade import util
+
+_logger = logging.getLogger(__name__)
+
+OLD_MODULE = "hr_employee_relative"
+NEW_MODULE = "l10n_do_hr"
+
+
+_MODELS = ["hr.employee.relative", "hr.employee.relative.relation"]
+_FIELDS = [("hr.employee", "relative_ids")]
+
+
+def migrate(cr, version):
+    if not util.module_installed(cr, OLD_MODULE):
+        _logger.info("%r is not installed; nothing to retire.", OLD_MODULE)
+        return
+
+    if not util.module_installed(cr, NEW_MODULE):
+        _logger.warning("%r is not installed; leaving %r untouched.", NEW_MODULE, OLD_MODULE)
+        return
+
+    for model in _MODELS:
+        util.move_model(cr, model, OLD_MODULE, NEW_MODULE)
+        _logger.info("Model re-homed: %r from %r to %r", model, OLD_MODULE, NEW_MODULE)
+
+    for model, fieldname in _FIELDS:
+        util.move_field_to_module(cr, model, fieldname, OLD_MODULE, NEW_MODULE)
+        _logger.info("Field re-homed: %s.%s from %r to %r", model, fieldname, OLD_MODULE, NEW_MODULE)
+
+    util.remove_module_deps(cr, NEW_MODULE, [OLD_MODULE])
+
+    cr.execute("UPDATE ir_module_module SET state = 'to remove' WHERE name = %s", [OLD_MODULE])
+    _logger.info("Module %r marked 'to remove'; %r owns the model from now on.", OLD_MODULE, NEW_MODULE)

--- a/src/l10n_do_banks/19.0.1.0.0/pre-module-merge.py
+++ b/src/l10n_do_banks/19.0.1.0.0/pre-module-merge.py
@@ -19,15 +19,15 @@ Affects (for each merge):
 
 import logging
 
-from odoo.upgrade import util
 from odoo.addons.base.maintenance.migrations import util as mig_util
+from odoo.upgrade import util
 
 _logger = logging.getLogger(__name__)
 
 _MERGES = [
     ("account_auto_transfer_features", "account_transfer_features"),
     ("payment_azul", "payment_azul_webpages"),
-    ("account_reconcile_payment", "l10n_do_account_withholding_tax")
+    ("account_reconcile_payment", "l10n_do_account_withholding_tax"),
 ]
 
 

--- a/src/l10n_do_banks/19.0.1.0.0/pre-modules-uninstall.py
+++ b/src/l10n_do_banks/19.0.1.0.0/pre-modules-uninstall.py
@@ -34,7 +34,6 @@ def uninstall_modules(cr):
         "l10n_do_sign_to_xml",
         "hr_course",
         "advanced_web_domain_widget",
-        "hr_employee_relative",
         "looker_connector",
         "stock_account_fields_tracking",
         "account_invoice_rate",


### PR DESCRIPTION
In v17 the OCA module hr_employee_relative owned the hr.employee.relative model (table, base fields, views) and l10n_do_hr extended it. In v19 l10n_do_hr declares hr.employee.relative and hr.employee.relative.relation with its own _name and no longer depends on the OCA module, so only ours must remain — while the shared hr_employee_relative table and every relative row have to survive.

Merging the module from a pre- script crashed the upgrade:

    Loading module hr_employee_relative (87/201)
    odoo.exceptions.MissingError: Record does not exist or has been deleted.
    (Record: ir.module.module(281,), User: 1)

merge_module DELETEs the ir_module_module row, but Odoo snapshots the module graph in STEP 3 of load_modules — freezing each node's id and state in module_graph._update_from_database — before any custom module's scripts run. The other merged modules are gone from the v19 addons path so they never enter that snapshot; hr_employee_relative is still shipped under odoo-pro/OCA/hr (an OCA submodule we do not control), so it does, and the row was deleted out from under it. No pre- script can fix this: uninstall_module additionally calls delete_model (dropping the table), and writing state='to remove' is undone because update_operation comes from the snapshot, not from the database — the module loads, reloads its data files and ends up installed again.

end-10-retire-hr-employee-relative.py runs in the end stage (STEP 3.5), once every module has been loaded and there is no snapshot left to contradict. It re-homes the models and the hr.employee.relative_ids field onto l10n_do_hr, drops the stale v17 dependency, and marks the module 'to remove' so Odoo's own STEP 5 runs module_uninstall() and reloads the registry without it. The data survives because ir.model.data._module_data_uninstall spares every record a surviving module also owns, which the move_* calls make explicit.

- end-10-retire-hr-employee-relative.py: new.
- pre-modules-uninstall: drop hr_employee_relative from the list; uninstall_module would delete_model and DROP the shared table.
- pre-module-merge: document that only modules absent from the v19 addons path may be merged there, so this is not reintroduced. Also list the account_reconcile_payment merge, which was missing from the docstring.

Verified on a v19 fixture with l10n_do_hr + l10n_do_banks + the OCA module installed and seeded relatives, with module versions rewound to their v17 values: the merge-from-pre- variant reproduces the MissingError, this one completes with the module uninstalled, the table and rows intact and the model owned by l10n_do_hr.