### PR TITLE
fix(l10n_do_banks): uninstall l10n_do_ecf_reception on 19.0 upgrade

### DIFF
--- a/src/l10n_do_banks/19.0.1.0.0/pre-modules-uninstall.py
+++ b/src/l10n_do_banks/19.0.1.0.0/pre-modules-uninstall.py
@@ -41,6 +41,7 @@ def uninstall_modules(cr):
         "sale_product_template_tags",
         "product_cost_security",
         "l10n_do_credit_note_ecf",
+        "l10n_do_ecf_reception",
         "sale_discount_display_amount",
         "simplify_access_management",
     ]


### PR DESCRIPTION
## Resumen

Se agrega `l10n_do_ecf_reception` a la lista de módulos que se desinstalan en el script `src/l10n_do_banks/19.0.1.0.0/pre-modules-uninstall.py`.

El módulo se coloca junto a los otros módulos legacy de e-CF ya presentes en la lista (`l10n_do_ecf_status_check`, `l10n_do_credit_note_ecf`), por lo que se desinstalará durante la fase `pre` del upgrade a 19.0 si está instalado.

## Cambios

- `src/l10n_do_banks/19.0.1.0.0/pre-modules-uninstall.py`: +1 entrada en `modules_to_uninstall`.

## Notas

El bucle existente ya valida con `util.module_installed` antes de desinstalar y captura excepciones por módulo, así que no se requiere lógica adicional: si el módulo no está instalado en una base de datos, simplemente se omite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VB224CVEojPcMgQ2NJnMHC)_