### PR TITLE
feat(l10n_do_banks): merge OCA stock_analytic on upgrade

### DIFF
--- a/src/l10n_do_banks/19.0.1.0.0/pre-module-merge.py
+++ b/src/l10n_do_banks/19.0.1.0.0/pre-module-merge.py
@@ -9,6 +9,7 @@ before any model/view loading takes place.
 Merges performed:
   - account_auto_transfer_features → account_transfer_features
   - payment_azul                   → payment_azul_webpages
+  - stock_analytic (OCA)           → stock_analytic_distribution_features
 
 Affects (for each merge):
   - ir_module_module          — module registry entry
@@ -28,6 +29,7 @@ _MERGES = [
     ("account_auto_transfer_features", "account_transfer_features"),
     ("payment_azul", "payment_azul_webpages"),
     ("account_reconcile_payment", "l10n_do_account_withholding_tax"),
+    ("stock_analytic", "stock_analytic_distribution_features"),
 ]
 
 


### PR DESCRIPTION
OCA never migrated stock_analytic to 19.0. Left alone it stays in the database as an inconsistent module, and whoever uninstalls it to clear that error drops the analytic_distribution columns of stock_move, stock_move_line and stock_scrap, losing every analytic imputation on the delivery notes.

Field, model and column names are identical in the replacement module stock_analytic_distribution_features (store-addons), so merge_module only moves metadata: no jsonb is rewritten and no analytic line is regenerated, so historical project costs cannot be duplicated. It also removes the old module row and force-installs the replacement.

Verified against a database built from a stock_analytic clone: without the merge the three columns are dropped, with it the jsonb and the existing analytic lines survive unchanged.